### PR TITLE
Add an ability to edit entries

### DIFF
--- a/controls.go
+++ b/controls.go
@@ -63,7 +63,7 @@ func keybindings(g *gocui.Gui) error {
 	if err := g.SetKeybinding("entries", gocui.KeyCtrlR, gocui.ModNone, deleteItem); err != nil {
 		return err
 	}
-	if err := g.SetKeybinding("entries", gocui.KeyArrowRight, gocui.ModNone, editEntry); err != nil {
+	if err := g.SetKeybinding("entries", gocui.KeyArrowRight, gocui.ModNone, startEditingEntry); err != nil {
 		return err
 	}
 	if err := g.SetKeybinding("output", gocui.KeyCtrlS, gocui.ModNone, save); err != nil {

--- a/controls.go
+++ b/controls.go
@@ -63,6 +63,9 @@ func keybindings(g *gocui.Gui) error {
 	if err := g.SetKeybinding("entries", gocui.KeyCtrlR, gocui.ModNone, deleteItem); err != nil {
 		return err
 	}
+	if err := g.SetKeybinding("entries", gocui.KeyArrowRight, gocui.ModNone, editEntry); err != nil {
+		return err
+	}
 	if err := g.SetKeybinding("output", gocui.KeyCtrlS, gocui.ModNone, save); err != nil {
 		return err
 	}

--- a/funcs.go
+++ b/funcs.go
@@ -387,15 +387,16 @@ func newEntry(g *gocui.Gui, v *gocui.View) error {
 	return err
 }
 
-// Edit existing entry
-func editEntry(g *gocui.Gui, v *gocui.View) error {
+// Enable edit mode for an existing entry
+// After editing the details of the entry its end time will be updated
+func startEditingEntry(g *gocui.Gui, v *gocui.View) error {
 	var err error
 	v.Highlight = false
 	ov, err := g.SetCurrentView("output")
 	if err != nil {
 		return err
 	}
-	if err = drawEntryBody(g, ov); err != nil {
+	if err = outputEntryDetails(g, ov); err != nil {
 		return err
 	}
 	ov.Editable = true
@@ -404,8 +405,9 @@ func editEntry(g *gocui.Gui, v *gocui.View) error {
 	return err
 }
 
-// Output only body of an entry for editing its text
-func drawEntryBody(g *gocui.Gui, v *gocui.View) error {
+// v will always equal output view
+// This outputs only the details of the entry for the purpose of further editing it
+func outputEntryDetails(g *gocui.Gui, v *gocui.View) error {
 	var err error
 
 	v.Clear()

--- a/funcs.go
+++ b/funcs.go
@@ -387,6 +387,37 @@ func newEntry(g *gocui.Gui, v *gocui.View) error {
 	return err
 }
 
+// Edit existing entry
+func editEntry(g *gocui.Gui, v *gocui.View) error {
+	var err error
+	v.Highlight = false
+	ov, err := g.SetCurrentView("output")
+	if err != nil {
+		return err
+	}
+	if err = drawEntryBody(g, ov); err != nil {
+		return err
+	}
+	ov.Editable = true
+	g.Cursor = true
+	ov.SetCursor(0, 0)
+	return err
+}
+
+// Output only body of an entry for editing its text
+func drawEntryBody(g *gocui.Gui, v *gocui.View) error {
+	var err error
+
+	v.Clear()
+	details := models.CurrentEntry.Details
+
+	if _, err := fmt.Fprintln(v, details); err != nil {
+		log.Println("Error writing entry to the output view:", err)
+	}
+
+	return err
+}
+
 // v will always equal output view
 // This saves the text in the output view and does what it needs to do
 // with it depending on what view it was called from (before switching to the output view).


### PR DESCRIPTION
This PR adds functionality of editing existing entries (it was one of the proposals in #3).

I made it in ranger-like style: on the entry that you want to edit, you should:
- press Right Arrow,
- edit the entry's details,
- and save it.

Also, Ctrl+E shortcut is already taken by the exporting task feature.