### PR TITLE
Fix collision between entries created within the same minute

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -95,7 +95,6 @@ func lineBelow(g *gocui.Gui, v *gocui.View) bool {
 
 // Copy the input view (iv) and handle it.
 // Used to add project or task.
-// TODO: Fix error that pops up when adding two entries in one minute
 func copyInput(g *gocui.Gui, iv *gocui.View) error {
 	var err error
 	// We want to read the view’s buffer from the beginning.

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ const (
 	// Tasks box width.
 	twidth = 44
 	// Entries box width.
-	ewidth = 62
+	ewidth = 65
 	// Input box height.
 	sheight = 3
 	// P is string for projects.

--- a/models/entry.go
+++ b/models/entry.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// TL is the time layout we will use.
-	TL = "2006-01-02 15:04"
+	TL = "2006-01-02 15:04:05"
 )
 
 // CurrentEntry holds the struct of the currently


### PR DESCRIPTION
I ran into a problem that appeared to be already noted in the code, that one cannot create an entry whilst one minute hasn't passed since the previous one creation.

This PR fixes it by adding seconds to the entry's name and begin/end time format.